### PR TITLE
Fix "browser-cookie-lite" broken export by replacing it with "cookie"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Check and use appropriate storage adapter for browser (localStorage, sessionStor
 ## Installation
 
 ```
-$ npm install superdevpack
+$ npm install local-storage-fallback
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/ripeworks/local-storage-fallback#readme",
   "dependencies": {
-    "browser-cookie-lite": "^1.0.4"
+    "cookie": "^0.3.1"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/src/CookieStorage.js
+++ b/src/CookieStorage.js
@@ -1,28 +1,51 @@
-import cookie from 'browser-cookie-lite'
+import cookie from 'cookie'
+
+const prefix = 'lS_'
 
 export default class CookieStorage {
   getItem(key) {
-    return cookie(key)
+    const cookies = cookie.parse(document.cookie)
+    if(!cookies || !cookies.hasOwnProperty(prefix + key)) {
+      return null
+    }
+    return cookies[prefix + key]
   }
 
   setItem(key, value) {
-    return cookie(key, value)
+    document.cookie = cookie.serialize(prefix + key, value, {
+      path: '/'
+    })
+    return value
   }
 
   removeItem(key) {
-    return cookie(key, '', -1)
+    document.cookie = cookie.serialize(prefix + key, '', {
+      path: '/',
+      maxAge: -1
+    });
+    return null
   }
 
   clear() {
-    return false
+    const cookies = cookie.parse(document.cookie)
+    for(var key in cookies) {
+      if(key.indexOf(prefix) === 0) {
+        this.removeItem(key.substr(prefix.length))
+      }
+    }
+
+    return null
   }
 }
 
 export function hasCookies() {
+  const {setItem, getItem, removeItem} = CookieStorage.prototype
+
   try {
     const TEST_KEY = '__test'
-    cookie(TEST_KEY, '1')
-    const value = cookie(TEST_KEY)
+    setItem(TEST_KEY, '1')
+    const value = getItem(TEST_KEY)
+    removeItem(TEST_KEY)
 
     return value == '1'
   } catch (e) {


### PR DESCRIPTION
Instead of exporting function as default, `browser-cookie-lite` do

```
this.cookie = …
```

where `this === module.exports`
I've fixed it by replacing [litejs/browser-cookie-lite](https://github.com/litejs/browser-cookie-lite) with RFC 6266 capable and more popular implementation - [jshttp/cookie](https://github.com/jshttp/cookie)

Also implemented `.clear` method and isolated `local-storage-fallback` cookies from regular cookies using prefix
