### PR TITLE
fix memory storage behaviour

### DIFF
--- a/src/MemoryStorage.js
+++ b/src/MemoryStorage.js
@@ -4,7 +4,7 @@ export default class MemoryStorage {
   }
 
   getItem (key) {
-    return this._data.hasOwnProperty(key) ? this._data[key] : undefined
+    return this._data.hasOwnProperty(key) ? this._data[key] : null
   }
 
   setItem (key, value) {


### PR DESCRIPTION
memory storage getItem method should return null instead of undefined to be consistent with other storages and webstorage spec