### PR TITLE
Allow empty prefix

### DIFF
--- a/src/CookieStorage.js
+++ b/src/CookieStorage.js
@@ -5,7 +5,7 @@ let prefix = 'lS_'
 export default class CookieStorage {
   constructor (options = {}) {
     this.cookieOptions = Object.assign({path: '/'}, options)
-    prefix = options.prefix || prefix
+    prefix = options.prefix === undefined ? prefix : options.prefix
   }
 
   getItem (key) {

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -37,3 +37,15 @@ test('specify cookie options', t => {
 
   t.is(document.cookie.indexOf('customPrefix'), 0)
 })
+
+test('specify cookie prefix option', t => {
+  storage.clear()
+
+  const cookieStorage = new CookieStorage({
+    prefix: ''
+  })
+
+  cookieStorage.setItem('test', 1)
+
+  t.is(document.cookie.indexOf('test'), 0)
+})


### PR DESCRIPTION
As described, I want to use empty prefix for `CookieStorage`

For example:
```
const storage = new CookieStorage({
  prefix: ''
})
```
