### PR TITLE
chore(security): bump cookie to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/ripeworks/local-storage-fallback#readme",
   "dependencies": {
-    "cookie": "^0.3.1"
+    "cookie": "^0.7.2"
   },
   "devDependencies": {
     "ava": "^0.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,9 +1336,10 @@ convert-to-spaces@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715"
 
-cookie@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+cookie@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-assert@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
Hello!  I'm hoping to apply a minor version bump for the `cookie` dependency in order to clear out a security alert.  Admittedly, it's a low alert so it's not a huge priority to merge, but it appears to work with the tests and when I use a resolution in my consuming repo so I thought it would be worth submitting as a PR